### PR TITLE
chore: remove push to main GHA event

### DIFF
--- a/.github/workflows/router-e2e-defer-tests.yml
+++ b/.github/workflows/router-e2e-defer-tests.yml
@@ -1,9 +1,6 @@
 name: E2E @defer Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
The merge queue makes running tests on push to `main` redundant. This removes the additional check.